### PR TITLE
fix: stop trying to fetch wasm server side

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@versori/golang-wasm-async-loader",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Golang Wasm loader for webpack that generates an async pattern for working with Go's WebAssembly output",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,9 +54,13 @@ function loader(this: webpack.LoaderContext<any>, contents: string) {
     const proxied = `
       require('!${libPath}');
       import gobridge from '${bridgePath}';
-      const file = fetch(__webpack_public_path__ + '${emittedFilename}');
-      const buffer = file.then(res => res.arrayBuffer());
-      export default gobridge(buffer);
+      let exportee = {}
+      if (typeof window !== 'undefined') {
+        const file = fetch(__webpack_public_path__ + '${emittedFilename}');
+        const buffer = file.then(res => res.arrayBuffer());
+        exportee= gobridge(buffer);
+      }
+      export default exportee;
     `;
     cb(null, proxied);
   });


### PR DESCRIPTION
We check for window, and if it's set load the wasm, otherwise set to an empty object.

Attempts to use the wasm server side will fail, but that's not our goal.